### PR TITLE
chore: add sample .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+# Environment variables for multi-streaming-stt
+AWS_REGION=ap-southeast-1
+AWS_ACCESS_KEY_ID=YOUR_AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY=YOUR_AWS_SECRET_ACCESS_KEY

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A real-time speech-to-text web application using AWS Transcribe Streaming with W
 - **Real-time Speech-to-Text**: Transcribe audio as you speak with minimal latency
 - **Speaker Diarization**: Automatically identify and label different speakers (A, B, C, etc.)
 - **WebSocket Streaming**: Direct browser-to-AWS connection using presigned URLs
-- **Multi-language Support**: Japanese (ja-JP) and English (en-US)
+- **Multi-language Support**: Thai (th-TH) and English (en-US)
 - **Partial Results Stabilization**: Get more accurate transcriptions with stabilized partial results
 - **Debug Panel**: Monitor connection status, latency, audio levels, and speaker mapping
 - **Modern UI**: Built with Next.js 15, Tailwind CSS v4, and shadcn/ui components
@@ -67,7 +67,7 @@ cp .env.local.example .env.local
 
 Edit `.env.local` with your AWS credentials:
 ```env
-AWS_REGION=ap-northeast-1
+AWS_REGION=ap-southeast-1
 AWS_ACCESS_KEY_ID=your-access-key
 AWS_SECRET_ACCESS_KEY=your-secret-key
 ```
@@ -81,7 +81,7 @@ Open [http://localhost:3000](http://localhost:3000) in your browser.
 
 ## Usage
 
-1. **Select Language**: Choose between Japanese (ja-JP) or English (en-US)
+1. **Select Language**: Choose between Thai (th-TH) or English (en-US)
 2. **Configure Options**:
    - **Expected Speakers**: Set the maximum number of speakers (auto, 2, or 3)
    - **Speaker Diarization**: Enable/disable speaker identification

--- a/app/api/transcribe/presign/route.ts
+++ b/app/api/transcribe/presign/route.ts
@@ -13,7 +13,7 @@ export async function GET(req: NextRequest) {
     if (!region) return NextResponse.json({ error: 'AWS_REGION is required' }, { status: 500 });
 
     const url = new URL(req.url);
-    const language = url.searchParams.get('language') ?? 'ja-JP';
+    const language = url.searchParams.get('language') ?? 'th-TH';
     const sampleRate = url.searchParams.get('sampleRate') ?? '16000';
     const diar = url.searchParams.get('diarization') === 'true';
     const stabilize = url.searchParams.get('stabilize') === 'true';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ import type { TranscriptionSettings } from '@/lib/types';
 
 export default function Page() {
   const [settings, setSettings] = useState<TranscriptionSettings>({
-    language: 'ja-JP',
+    language: 'th-TH',
     diarization: true,
     stabilize: true,
     showPartial: false,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -16,9 +16,9 @@ export const WEBSOCKET_CONFIG = {
 
 // UI configuration
 export const UI_CONFIG = {
-  DEFAULT_LANGUAGE: 'ja-JP' as const,
+  DEFAULT_LANGUAGE: 'th-TH' as const,
   LANGUAGES: [
-    { value: 'ja-JP', label: 'ja-JP (Japanese)' },
+    { value: 'th-TH', label: 'th-TH (Thai)' },
     { value: 'en-US', label: 'en-US (English)' },
   ] as const,
   SPEAKER_COUNTS: [

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -34,7 +34,7 @@ export interface PresignResponse {
 }
 
 // Language options
-export type LanguageCode = 'ja-JP' | 'en-US';
+export type LanguageCode = 'th-TH' | 'en-US';
 
 // Speaker count options
 export type SpeakerCount = 'auto' | '2' | '3';


### PR DESCRIPTION
## Summary
- add example `.env` with placeholders for AWS configuration
- switch default AWS Transcribe language from Japanese to Thai across code and docs

## Testing
- `pnpm lint` *(fails: Unexpected any, no-unused-vars, etc.)*


------
https://chatgpt.com/codex/tasks/task_b_689ea3f9e5d48326be35b2e2bc09795d